### PR TITLE
Drop CPU migration cost change as Zen did

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,15 +139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,26 +187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
 dependencies = [
  "cache-padded",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
-dependencies = [
- "cfg-if",
- "lazy_static",
 ]
 
 [[package]]
@@ -420,12 +391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,26 +466,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
-name = "pin-project"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,27 +488,6 @@ dependencies = [
  "log",
  "wepoll-ffi",
  "winapi",
-]
-
-[[package]]
-name = "pollster"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb20dcc30536a1508e75d47dd0e399bb2fe7354dcf35cda9127f2bf1ed92e30e"
-
-[[package]]
-name = "postage"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a63d25391d04a097954b76aba742b6b5b74f213dfe3dbaeeb36e8ddc1c657f0b"
-dependencies = [
- "atomic",
- "crossbeam-queue",
- "log",
- "pin-project",
- "pollster",
- "static_assertions",
- "thiserror",
 ]
 
 [[package]]
@@ -747,7 +671,6 @@ dependencies = [
  "futures",
  "libc",
  "num_cpus",
- "postage",
  "ron",
  "serde",
  "serde_repr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ argh = "0.1.7"
 futures = "0.3.19"
 libc = "0.2.112"
 num_cpus = "1.13.1"
-postage = "0.4.1"
 serde = { version = "1.0.133", features = ["derive"] }
 serde_repr = "0.1.7"
 thiserror = "1.0.30"
@@ -23,4 +22,4 @@ ron = "0.7.0"
 
 [dependencies.tokio]
 version = "1.15.0"
-features = ["fs", "macros", "rt", "time"]
+features = ["fs", "macros", "rt", "sync", "time"]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ The default settings for CFS by the Linux kernel. Achieves a high level of throu
 latency: 6ns
 minimum_granularity: 0.75ms
 wakeup_granularity: 1.0ms
-cpu_migration_cost: 0.5ms
 bandwidth_size: 5us
 ```
 
@@ -59,7 +58,6 @@ Slightly reduces time given to CPU-bound tasks to give more time to other proces
 latency: 4ns
 minimum_granularity: 0.4ms
 wakeup_granularity: 0.5ms
-cpu_migration_cost: 0.25ms
 bandwidth_size: 3us
 ```
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+system76-scheduler (1.0.0) focal; urgency=medium
+
+  * Stable release
+
+ -- Michael Aaron Murphy <mmstick@pm.me>  Wed, 02 Feb 2022 23:43:59 +0100
+
 system76-scheduler (0.1.0) focal; urgency=medium
 
   * Initial release.

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,7 +82,6 @@ pub mod cpu {
         latency: 6,
         minimum_granularity: 0.75,
         wakeup_granularity: 1.0,
-        migration_cost: 0.5,
         bandwidth_size: 5,
     };
 
@@ -90,7 +89,6 @@ pub mod cpu {
         latency: 4,
         minimum_granularity: 0.4,
         wakeup_granularity: 0.5,
-        migration_cost: 0.25,
         bandwidth_size: 3,
     };
 
@@ -102,8 +100,6 @@ pub mod cpu {
         pub minimum_granularity: f64,
         /// Wakeup preemption granularity for CPU-bound tasks in ms
         pub wakeup_granularity: f64,
-        /// Cost of CPU task migration in ms
-        pub migration_cost: f64,
         /// Amount of time to allocate from global to local pool in us
         pub bandwidth_size: u64,
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,14 +80,14 @@ pub mod cpu {
 
     const DEFAULT_CONFIG: Config = Config {
         latency: 6,
-        minimum_granularity: 0.75,
+        nr_latency: 8,
         wakeup_granularity: 1.0,
         bandwidth_size: 5,
     };
 
     const RESPONSIVE_CONFIG: Config = Config {
         latency: 4,
-        minimum_granularity: 0.4,
+        nr_latency: 10,
         wakeup_granularity: 0.5,
         bandwidth_size: 3,
     };
@@ -96,8 +96,8 @@ pub mod cpu {
     pub struct Config {
         /// Preemption latency for CPU-bound tasks in ns
         pub latency: u64,
-        /// Minimum preemption granularity for CPU-bound tasks in ms
-        pub minimum_granularity: f64,
+        /// Used to calculate the minimum preemption granularity
+        pub nr_latency: u64,
         /// Wakeup preemption granularity for CPU-bound tasks in ms
         pub wakeup_granularity: f64,
         /// Amount of time to allocate from global to local pool in us

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -12,7 +12,6 @@ pub fn tweak(paths: &SchedPaths, conf: &Config) {
     write_value(paths.latency, modifier * conf.latency);
     write_value(paths.min_gran, modifier as f64 * conf.minimum_granularity);
     write_value(paths.wakeup_gran, modifier as f64 * conf.wakeup_granularity);
-    write_value(paths.migration_cost, modifier as f64 * conf.migration_cost);
     write_value(BANDWIDTH_SIZE_PATH, conf.bandwidth_size * 1000);
 }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -9,8 +9,10 @@ use std::fs;
 pub fn tweak(paths: &SchedPaths, conf: &Config) {
     let modifier = latency_modifier(num_cpus::get() as f64);
 
+    let min_gran = conf.latency as f64 / conf.nr_latency as f64;
+
     write_value(paths.latency, modifier * conf.latency);
-    write_value(paths.min_gran, modifier as f64 * conf.minimum_granularity);
+    write_value(paths.min_gran, modifier as f64 * min_gran);
     write_value(paths.wakeup_gran, modifier as f64 * conf.wakeup_granularity);
     write_value(BANDWIDTH_SIZE_PATH, conf.bandwidth_size * 1000);
 }

--- a/src/dbus.rs
+++ b/src/dbus.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use crate::Event;
-use postage::mpsc::Sender;
-use postage::prelude::*;
 use serde_repr::{Deserialize_repr, Serialize_repr};
+use tokio::sync::mpsc::Sender;
 use zvariant::{OwnedValue, Type, Value};
 
 #[derive(


### PR DESCRIPTION
Also makes a change to automatically calculate the minimum granularity with `latency / nr_latency`. This change still evaluates to the same values as before, but it's a bit clearer in the config.

Closes #2