### PR TITLE
Add a debian/conffiles for the configuration files

### DIFF
--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,0 +1,2 @@
+/var/share/system76-scheduler/config.ron
+/var/share/system76-scheduler/assignments/default.ron


### PR DESCRIPTION
Prevents the default `/usr/share/system76-scheduler/config.ron` and `/usr/share/system76-scheduler/assignments/default.ron` files from being blindly overwritten on upgrade.

Fixes #23

Some of the built-in configuration files under `/var/share/system76-scheduler` do not have equivalents in /etc (e.g. the top level `config.ron`), or sometimes the default assignments need changing and/or suppression. This requires editing these non etc files for editing.

Problem is that `dpkg` thinks of them like any other file, like a binary. So it blindly replaces any changes the user made in these with the defaults from the .deb file on upgrade.

This file will tell `dpkg` that it should anticipate these could be user edited, and if so, try to perform a merge on them.

Package files installed under `/etc` are automatically considered config files, so no need to list them.

Sadly, wildcards do not seem to be supported at this time, so this file will need to be manually updated a new configuration `.ron` file is added to the package.

See https://www.debian.org/doc/manuals/maint-guide/dother.en.html#conffiles