### PR TITLE
Warn that built-in .ron configs changes are not preserved

### DIFF
--- a/data/auto.ron
+++ b/data/auto.ron
@@ -1,7 +1,5 @@
-// WARNING: This file will not have modifications preserved on upgrade.
-// The same holds for any file under /usr/share/system76-scheduler/
-//
-// Instead, make new .ron files under /etc/system76-scheduler/assignments/ to configure.
+// WARNING: Modifications to this file will not be preserved on upgrade.
+// To configure, make new .ron files under /etc/system76-scheduler/assignments/.
 
 {
 // High priority

--- a/data/auto.ron
+++ b/data/auto.ron
@@ -1,3 +1,8 @@
+// WARNING: This file will not have modifications preserved on upgrade.
+// The same holds for any file under /usr/share/system76-scheduler/
+//
+// Instead, make new .ron files under /etc/system76-scheduler/assignments/ to configure.
+
 {
 // High priority
 -5: [

--- a/data/config.ron
+++ b/data/config.ron
@@ -1,3 +1,6 @@
+// WARNING: This file will not have modifications preserved on upgrade.
+// Instead, make a config.ron file under /etc/system76-scheduler/ to configure.
+
 (
 // The priority to assign background tasks.
 background: Some(5),

--- a/data/config.ron
+++ b/data/config.ron
@@ -1,5 +1,5 @@
-// WARNING: This file will not have modifications preserved on upgrade.
-// Instead, make a config.ron file under /etc/system76-scheduler/ to configure.
+// WARNING: Modifications to this file will not be preserved on upgrade.
+// To configure, make a config.ron file under /etc/system76-scheduler/.
 
 (
 // The priority to assign background tasks.


### PR DESCRIPTION
By design, the default config `/usr/share/system76-scheduler` will not have changes preserved.
So this comment serves as a warning of this fact, as some may expect `dpkg` to preserve changes as if they were config files.

See #23 with context