### PR TITLE
Log an error if config parsing failed for assignment `.ron`s

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,13 @@ impl Config {
                 match ron::from_str(config) {
                     Ok(config) => return config,
                     Err(why) => {
-                        tracing::error!("Error while reading {}:\n{:?}", path, why);
+												tracing::error!(
+														"{:?}: {} on line {}, column {}",
+														path,
+														why.code,
+														why.position.line,
+														why.position.col
+												);
                     }
                 }
             }
@@ -67,7 +73,13 @@ impl Config {
 				                        }
 				                    },
 				                    Err(why) => {
-				                      tracing::error!("Error while reading {:?}:\n{:?}", entry.path(), why);
+																tracing::error!(
+																		"{:?}: {} on line {}, column {}",
+																		entry.path(),
+																		why.code,
+																		why.position.line,
+																		why.position.col
+																);
 				                    }
                         }
                     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,7 @@ impl Config {
                 match ron::from_str(config) {
                     Ok(config) => return config,
                     Err(why) => {
-                        tracing::error!("{}: {:?}", path, why);
+                        tracing::error!("Error while reading {}:\n{:#?}", path, why);
                     }
                 }
             }
@@ -67,7 +67,7 @@ impl Config {
 				                        }
 				                    },
 				                    Err(why) => {
-				                      tracing::error!("{:#?}: {:?}", entry, why);
+				                      tracing::error!("Error while reading {:?}:\n{:#?}", entry.path(), why);
 				                    }
                         }
                     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,13 +58,17 @@ impl Config {
             if let Ok(dir) = directory.read_dir() {
                 for entry in dir.filter_map(Result::ok) {
                     if let Ok(string) = fs::read_to_string(entry.path()) {
-                        if let Ok(buffer) = ron::from_str::<BTreeMap<i8, HashSet<String>>>(&string)
-                        {
-                            for (priority, commands) in buffer {
-                                for command in commands {
-                                    assignments.insert(command, priority);
-                                }
-                            }
+                        match ron::from_str::<BTreeMap<i8, HashSet<String>>>(&string) {
+                            Ok(buffer) => {
+				                        for (priority, commands) in buffer {
+				                            for command in commands {
+				                                assignments.insert(command, priority);
+				                            }
+				                        }
+				                    },
+				                    Err(why) => {
+				                      tracing::error!("{:#?}: {:?}", entry, why);
+				                    }
                         }
                     }
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,7 @@ impl Config {
                 match ron::from_str(config) {
                     Ok(config) => return config,
                     Err(why) => {
-                        tracing::error!("Error while reading {}:\n{:#?}", path, why);
+                        tracing::error!("Error while reading {}:\n{:?}", path, why);
                     }
                 }
             }
@@ -67,7 +67,7 @@ impl Config {
 				                        }
 				                    },
 				                    Err(why) => {
-				                      tracing::error!("Error while reading {:?}:\n{:#?}", entry.path(), why);
+				                      tracing::error!("Error while reading {:?}:\n{:?}", entry.path(), why);
 				                    }
                         }
                     }


### PR DESCRIPTION
See #26: this fixes the "failed to parse" situation