### PR TITLE
Add amsynth to the "high priority" section

### DIFF
--- a/data/auto.ron
+++ b/data/auto.ron
@@ -4,6 +4,7 @@
 {
 // High priority
 -5: [
+    "amsynth",
     "gnome-shell",
     "kwin",
     "sway",


### PR DESCRIPTION
amsynth is a popular FOSS MIDI softsynth. To the scheduler, it doesn't look like an important task. Because of that, the scheduler currently gives it a nice value of 5. However, that spells trouble for audio applications because a higher priority task can steal CPU time and create pops or breaks in the synth output. Therefore, amsynth (and maybe other similar pro audio programs, too) should be treated as "high priority."