### PR TITLE
Prevent pipewire audio crackling due to rtkit demotion

### DIFF
--- a/data/assignments.ron
+++ b/data/assignments.ron
@@ -2,6 +2,12 @@
 // To configure, make new .ron files under /etc/system76-scheduler/assignments/.
 
 {
+// Prevent audio crackling from sound services.
+(-11, Realtime(0)): [
+    "pipewire",
+    "pipewire-pulse",
+    "wireplumber"
+],
 // Very high
 (-9, BestEffort(0)): [
     "easyeffects",

--- a/data/exceptions.ron
+++ b/data/exceptions.ron
@@ -2,7 +2,6 @@
 // To configure, make new .ron files under /etc/system76-scheduler/exceptions/.
 
 [
-    "pipewire",
-    "pipewire-pulse",
-    "wireplumber"
+    "ionice",
+    "nice",
 ]


### PR DESCRIPTION
Some systems are having their pipewire processes demoted from a realtime priority on resume from suspend. This adds a new realtime priority configuration for the pipewire processes, and makes some changes in the daemon to make it possible to enforce a high priority adjustment to a high priority process.

Testing should ensure that

- Pipewire retains realtime priority after resuming from suspend (may take up to 60s for an afflicted system to re-apply the high priority)
- That it's possible to set a different priority for Pipewire, such as `-15`.
- And of course no regressions for current behavior