### PR TITLE
Add javac to the lowest priority as a compiler

### DIFF
--- a/data/assignments.ron
+++ b/data/assignments.ron
@@ -101,6 +101,7 @@
     "g++",
     "gcc",
     "gradle",
+    "javac",
     "lld",
     "make",
     "mold",


### PR DESCRIPTION
`javac` is the Java compiler, and thus should be with the other compilers.

The previous (already removed) entry of `java` was the Java runtime, but this has that crucial `'c'` at the end of it.