### PR TITLE
Add tracker-extract-3 (normally nice 19) to Idle

### DIFF
--- a/data/assignments.ron
+++ b/data/assignments.ron
@@ -108,6 +108,7 @@
     "mold",
     "mvn",
     "rustc",
+    "tracker-extract-3",
     "tracker-miner-fs-3",
     "update-initramfs",
     "packagekitd",


### PR DESCRIPTION
This process is spawned at nice value `19` by default, but was changed to `5` by S76-scheduler. It's part of the `tracker-extract` package the same as `tracker-miner-fs-3`.