### PR TITLE
Add rtkit-daemon to exceptions

### DIFF
--- a/data/exceptions.ron
+++ b/data/exceptions.ron
@@ -4,4 +4,5 @@
 [
     "ionice",
     "nice",
+    "rtkit-daemon",
 ]


### PR DESCRIPTION
It will try to manage it's own priority, and as a manager for real-time scheduling access from userspace, I think we should let it.

Examples of the two fighting:
```
...
Process changed priority at 1654504104.44: 5 to 1, 5705: ['/usr/libexec/rtkit-daemon']
Process changed priority at 1654504115.49: 1 to 5, 5705: ['/usr/libexec/rtkit-daemon']
Process changed priority at 1654504261.58: 5 to 1, 5705: ['/usr/libexec/rtkit-daemon']
Process changed priority at 1654504295.37: 1 to 5, 5705: ['/usr/libexec/rtkit-daemon']
Process changed priority at 1654504379.53: 5 to 1, 5705: ['/usr/libexec/rtkit-daemon']
Process changed priority at 1654504415.54: 1 to 5, 5705: ['/usr/libexec/rtkit-daemon']
Process changed priority at 1654504481.20: 5 to 1, 5705: ['/usr/libexec/rtkit-daemon']
Process changed priority at 1654504535.44: 1 to 5, 5705: ['/usr/libexec/rtkit-daemon']
...
```
And this goes on for as long as the two are running. Output is from a [script I wrote](https://gist.github.com/robobenklein/26306aaf733343a28ae8bb7bfd02cecc) to try and debug this.