### PR TITLE
cargo: ron: don't refer to moved branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,7 +788,7 @@ dependencies = [
 [[package]]
 name = "ron"
 version = "0.7.0"
-source = "git+https://github.com/MomoLangenstein/ron?branch=253-untagged-enums#a9c5444d74677716f4a8a00504fb1bedbde55156"
+source = "git+https://github.com/MomoLangenstein/ron?rev=a9c5444d74677716f4a8a00504fb1bedbde55156#a9c5444d74677716f4a8a00504fb1bedbde55156"
 dependencies = [
  "base64",
  "bitflags",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -33,7 +33,7 @@ clap = { version = "3.1.18", features = ["cargo"] }
 # Necessary for deserialization of untagged enums in assignments.
 [dependencies.ron]
 git = "https://github.com/MomoLangenstein/ron"
-branch = "253-untagged-enums"
+rev = "a9c5444d74677716f4a8a00504fb1bedbde55156"
 
 [dependencies.tracing-subscriber]
 version = "0.3.11"


### PR DESCRIPTION
The revision or `ron` in `daemon/Cargo.toml` refers to a branch that has been force-pushed, which invalidates `Cargo.lock` and breaks build.  Fix by referring to the desired commit directly (which is still reachable from the `master` branch, so hopefully won't go away)