### PR TITLE
`INSTALL.md`: Provide installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,34 @@
+# `INSTALL`
+
+## Requirements
+
+### Fedora
+
+```bash
+sudo dnf install just libusb1-devel dbus-devel bpftrace libbpf-tools bcc-tools
+# Probably not needed
+sudo dnf install bcc-lua bcc-devel
+```
+
+Then determine the path to `execsnoop` as such:
+
+```bash
+$ rpm -ql bcc-tools | grep -i execsnoop
+/usr/share/bcc/tools/doc/execsnoop_example.txt
+/usr/share/bcc/tools/execsnoop
+/usr/share/man/man8/bcc-execsnoop.8.gz
+```
+
+As it can be seen from the previous output, it is not `/usr/sbin/execsnoop-bpfcc` but rather it is  `/usr/share/bcc/tools/execsnoop`. This requires us to set `EXECSNOOP_PATH` to `/usr/share/bcc/tools/execsnoop` before we build.
+
+## Build and Install
+
+```bash
+env EXECSNOOP_PATH=/usr/share/bcc/tools/execsnoop just
+sudo just install
+sudo systemctl daemon-reload
+sudo systemctl enable --now com.system76.Scheduler
+sudo systemctl start --now com.system76.Scheduler
+sudo systemctl status com.system76.Scheduler
+journalctl --unit com.system76.Scheduler --follow
+```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Scheduling service which optimizes Linux's CPU scheduler and automatically assig
 
 These changes result in a noticeable improvement in the experienced smoothness and performance of applications and games. The improved responsiveness of applications is most noticeable on older systems with budget hardware, whereas games will benefit from higher framerates and reduced jitter. This is because background applications and services will be given a smaller portion of leftover CPU budget after the active process has had the most time on the CPU.
 
+## Install
+
+See [`./INSTALL.md`](./INSTALL.md) for installation instructions.
+
 ## DBus
 
 - Interface: `com.system76.Scheduler`

--- a/justfile
+++ b/justfile
@@ -20,11 +20,11 @@ confdir := rootdir + sysconfdir
 target_bin := bindir + '/' + binary
 
 # Path to execsnoop binary.
-execsnoop := '/usr/sbin/execsnoop-bpfcc'
+execsnoop_path := env_var_or_default('EXECSNOOP_PATH', '/usr/sbin/execsnoop-bpfcc')
 
 # Compile pop-launcher
 all: _extract_vendor
-    env EXECSNOOP_PATH={{execsnoop}} cargo build {{cargo_args}}
+    env EXECSNOOP_PATH={{execsnoop_path}} cargo build {{cargo_args}}
 
 # Remove Cargo build artifacts
 clean:
@@ -32,7 +32,7 @@ clean:
 
 # Run `cargo check`
 check:
-    env EXECSNOOP_PATH={{execsnoop}} cargo check
+    env EXECSNOOP_PATH={{execsnoop_path}} cargo check
 
 # Also remove .cargo and vendored dependencies
 distclean:


### PR DESCRIPTION
`justfile`
----------

Adjust the file a little so that it also builds on non-Debian based systems where `execsnoop` is not `/usr/sbin/execsnoop-bpfcc` nor is it in `/usr/sbin`.

`INSTALL.md`
------------

Provide installation instructions for Fedora.

---

Signed-off-by: Mohamed Bana <mohamed@bana.io>