### PR TITLE
fix(cfs): Apply CFS config when cfs_profiles is enabled

### DIFF
--- a/daemon/src/service.rs
+++ b/daemon/src/service.rs
@@ -269,7 +269,7 @@ impl<'owner> Service<'owner> {
     }
 
     pub fn cfs_apply(&self, config: &crate::config::cfs::Profile) {
-        if self.config.cfs_profiles.enable {
+        if !self.config.cfs_profiles.enable {
             return;
         }
 


### PR DESCRIPTION
Fix a typo in service.rs, otherwise CFS profiles are applied only when CFS profiles are not enabled.