### PR TITLE
fix(pw): insert to active_sessions, avoid creating duplicated threads

### DIFF
--- a/daemon/src/pw.rs
+++ b/daemon/src/pw.rs
@@ -74,6 +74,7 @@ async fn pipewire_service(tx: Sender<ProcessEvent>) {
                 SocketEvent::Add(socket) => {
                     if !active_sessions.contains(&socket) {
                         if let Ok(stream) = UnixStream::connect(&socket) {
+                            active_sessions.insert(socket.clone());
                             let tx = tx.clone();
                             let pw_tx = pw_tx.clone();
                             std::thread::spawn(move || {


### PR DESCRIPTION
In `daemon/src/pw.rs`, `pipewire_service()` with `pw_tx` and `pw_rx`:
- `session_monitor` checks `/run/user/pipewire-0` every 60s, and if find one, send `SocketEvent::Add(socket)` from `pw_tx`
- `session_spawner` receives from `pw_rx`, and creates a thread if it is `SocketEvent::Add(socket)`

`BTreeSet<PathBuf>` is defined to "deduplicate" socket names. However, it seems that this BTreeSet is always empty, as no one is inserting anything into it. Thus this daemon will actually create a thread every 60s, probably an unexpected behavior.