### PR TITLE
add hyprland to default list of desktop environments

### DIFF
--- a/data/pop_os.kdl
+++ b/data/pop_os.kdl
@@ -34,6 +34,7 @@ assignments {
 		i3wm
 		kwin
 		sway
+		Hyprland
 		gamescope
 		Xorg
 	}


### PR DESCRIPTION
Title pretty much says it all. It's easy enough to add a 
```
	(-5, BestEffort(4)): [
		"Hyprland"
	],
```

to the assignments directory, but still would be nice if it just worked by default
