### PR TITLE
fix: sched_setscheduler() gets EINVAL for normal policies

### DIFF
--- a/config/src/scheduler/mod.rs
+++ b/config/src/scheduler/mod.rs
@@ -180,6 +180,14 @@ impl FromStr for SchedPolicy {
     }
 }
 
+impl SchedPolicy {
+    /// Whether the policy is realtime (FIFO or RR)
+    #[must_use]
+    pub fn is_realtime(self) -> bool {
+        matches!(self, Self::Fifo | Self::Rr)
+    }
+}
+
 /// A value between 1 and 99
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SchedPriority(u8);

--- a/daemon/src/priority.rs
+++ b/daemon/src/priority.rs
@@ -45,7 +45,13 @@ pub fn set(buffer: &mut Buffer, process: u32, profile: &Profile) {
 
 pub fn set_policy(pid: u32, policy: SchedPolicy, sched_priority: SchedPriority) {
     let param = libc::sched_param {
-        sched_priority: libc::c_int::from(sched_priority.get()),
+        sched_priority: libc::c_int::from({
+            if policy.is_realtime() {
+                sched_priority.get()
+            } else {
+                0
+            }
+        }),
     };
 
     unsafe {


### PR DESCRIPTION
By stracing system76-scheduler daemon, it could be found that most calls to `sched_setscheduler()` returns EINVAL:

```
sched_setscheduler(2730973, SCHED_IDLE, [1]) = -1 EINVAL (Invalid argument)
sched_setscheduler(2730974, SCHED_IDLE, [1]) = -1 EINVAL (Invalid argument)
sched_setscheduler(2730975, SCHED_IDLE, [1]) = -1 EINVAL (Invalid argument)
sched_setscheduler(2730984, SCHED_OTHER, [1]) = -1 EINVAL (Invalid argument)
sched_setscheduler(2730985, SCHED_OTHER, [1]) = -1 EINVAL (Invalid argument)
sched_setscheduler(2730986, SCHED_OTHER, [1]) = -1 EINVAL (Invalid argument)
sched_setscheduler(2730987, SCHED_OTHER, [1]) = -1 EINVAL (Invalid argument)
^Cstrace: Process 2730332 detached
```

In `sched_setscheduler(2)` it says that:

```
       Currently, Linux supports the following "normal" (i.e., non-real-time)  scheduling
       policies as values that may be specified in policy:

       SCHED_OTHER   the standard round-robin time-sharing policy;

       SCHED_BATCH   for "batch" style execution of processes; and

       SCHED_IDLE    for running very low priority background jobs.

       For each of the above policies, param->sched_priority must be 0.

       Various  "real-time" policies are also supported, for special time-critical appli‐
       cations that need precise control over the way in which runnable threads  are  se‐
       lected  for execution.  For the rules governing when a process may use these poli‐
       cies, see sched(7).  The real-time policies that may be specified in policy are:

       SCHED_FIFO    a first-in, first-out policy; and

       SCHED_RR      a round-robin policy.

       For each of the above policies, param->sched_priority specifies a scheduling  pri‐
       ority  for  the  thread.   This  is  a  number  in  the  range returned by calling
       sched_get_priority_min(2) and sched_get_priority_max(2) with the specified policy.
       On Linux, these system calls return, respectively, 1 and 99.
...
...
...
       EINVAL (sched_setscheduler()) param does not make sense for the specified policy.
```

Thus `SchedPriority` is only meaningful for FIFO & RR policy. This PR tries addressing this bug by using sched_priority value in `set_policy()` only when the policy is a real-time one.