### PR TITLE
Correct SetForegroundProcess method name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ sudo just sysconfdir=/usr/share install
 - Interface: `com.system76.Scheduler`
 - Path: `/com/system76/Scheduler`
 
-The `SetForeground(u32)` method can be called to change the active foreground process.
+The `SetForegroundProcess(u32)` method can be called to change the active foreground process.
 
 ## Scheduler Config
 


### PR DESCRIPTION
I just spent 15 minutes wondering why dbus is telling me the method doesn't exist. This corrects the name of the SetForegroundProcess method in the README