### PR TITLE
Fix: remove sched=(fifo)49 from sound-server assignments

### DIFF
--- a/data/config.kdl
+++ b/data/config.kdl
@@ -27,7 +27,7 @@ process-scheduler enable=true {
     // Preset process assignment profiles
     assignments {
         // Prevent crackling and distortion from the sound server
-        sound-server nice=-15 sched=(fifo)49 io=(realtime)0 {
+        sound-server nice=-15 io=(realtime)0 {
             "/usr/bin/pipewire"
             "/usr/bin/pipewire-pulse"
             "/usr/bin/jackd"


### PR DESCRIPTION
It seems like realtime priorities were not being set properly with the existing configuration setting, which causes audio underruns and audible glitches.

Fixes https://github.com/pop-os/system76-scheduler/issues/114